### PR TITLE
Update Version to 2.8.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.vexsoftware
-version=3.0.0-SNAPSHOT
+version=2.8.0-SNAPSHOT


### PR DESCRIPTION
The last changes didn't provide any breaking changes. Therefore the major version 3.0.0-SNAPSHOT is not needed.